### PR TITLE
Remove margin-bottom for matching-numbers game

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -787,7 +787,6 @@ main {
     font-family: 'CabritoNorBol';
     color: #fff;
     text-align: center;
-    margin-bottom: 15px;
     font-size: 18px;
 }
 .message_board {


### PR DESCRIPTION
That style was pushing the CTA to close to the bottom.